### PR TITLE
Adding backup for vericite configs

### DIFF
--- a/backup/moodle2/backup_plagiarism_vericite_plugin.class.php
+++ b/backup/moodle2/backup_plagiarism_vericite_plugin.class.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+
+class backup_plagiarism_vericite_plugin extends backup_plagiarism_plugin {
+    protected function define_module_plugin_structure() {
+        $plugin = $this->get_plugin_element();
+        $pluginwrapper = new backup_nested_element($this->get_recommended_name());
+        $plugin->add_child($pluginwrapper);
+
+        $vericiteconfigs = new backup_nested_element('vericite_configs');
+        $vericiteconfig = new backup_nested_element('vericite_config', array('id'), array('name', 'value'));
+        $pluginwrapper->add_child($vericiteconfigs);
+        $vericiteconfigs->add_child($vericiteconfig);
+        $vericiteconfig->set_source_table('plagiarism_vericite_config', array('cm' => backup::VAR_PARENTID));
+    }
+}

--- a/backup/moodle2/restore_plagiarism_vericite_plugin.class.php
+++ b/backup/moodle2/restore_plagiarism_vericite_plugin.class.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+
+class restore_plagiarism_vericite_plugin extends restore_plagiarism_plugin {
+    protected $existingcourse;
+
+    protected function define_module_plugin_structure() {
+        $paths = array();
+
+        $elename = 'vericiteconfigmod';
+        $elepath = $this->get_pathfor('vericite_configs/vericite_config');
+        $paths[] = new restore_path_element($elename, $elepath);
+
+        return $paths;
+
+    }
+
+    public function process_vericiteconfigmod($data) {
+        global $DB;
+
+        if ($this->task->is_samesite() && !$this->existingcourse) {
+            if (! is_object($data)) {
+                $data = (object) $data;
+            }
+            $recexists = $DB->record_exists(
+                'plagiarism_vericite_config',
+                array('name' => $data->name, 'value' => $data->value, 'cm' => $this->task->get_moduleid())
+            );
+            if (!$recexists) {
+                $data = (object)$data;
+                $data->cm = $this->task->get_moduleid();
+
+                $DB->insert_record('plagiarism_vericite_config', $data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds basic moodle backup and restore classes to the plugin so that the values in the plagiarism_vericite_config table are backed up and restored. Since we often use backup\restore as a course templating process we needed the Vericite configs to carry over into the restored course.
