### PR TITLE
Adding backup\restore for score, files and tokens

### DIFF
--- a/backup/moodle2/backup_plagiarism_vericite_plugin.class.php
+++ b/backup/moodle2/backup_plagiarism_vericite_plugin.class.php
@@ -19,6 +19,7 @@ defined('MOODLE_INTERNAL') || die();
 
 class backup_plagiarism_vericite_plugin extends backup_plagiarism_plugin {
     protected function define_module_plugin_structure() {
+        $userinfo = $this->get_setting_value('userinfo');
         $plugin = $this->get_plugin_element();
         $pluginwrapper = new backup_nested_element($this->get_recommended_name());
         $plugin->add_child($pluginwrapper);
@@ -28,5 +29,35 @@ class backup_plagiarism_vericite_plugin extends backup_plagiarism_plugin {
         $pluginwrapper->add_child($vericiteconfigs);
         $vericiteconfigs->add_child($vericiteconfig);
         $vericiteconfig->set_source_table('plagiarism_vericite_config', array('cm' => backup::VAR_PARENTID));
+
+        $vericitescores = new backup_nested_element('vericite_scores');
+        $vericitescore = new backup_nested_element('vericite_score', array('id'), array('timeretrieved'));
+        $pluginwrapper->add_child($vericitescores);
+        $vericitescores->add_child($vericitescore);
+        $vericitescore->set_source_table('plagiarism_vericite_score', array('cm' => backup::VAR_PARENTID));
+
+        $vericitefiles = new backup_nested_element('vericite_files');
+        $vericitefile = new backup_nested_element(
+            'vericite_file',
+            array('id'),
+            array('userid', 'identifier', 'similarityscore', 'timeretrieved', 'data', 'status', 'attempts')
+        );
+        $pluginwrapper->add_child($vericitefiles);
+        $vericitefiles->add_child($vericitefile);
+        if ($userinfo) {
+            $vericitefile->set_source_table('plagiarism_vericite_files', array('cm' => backup::VAR_PARENTID));
+        }
+
+        $vericitetokens = new backup_nested_element('vericite_tokens');
+        $vericitetoken = new backup_nested_element(
+            'vericite_token',
+            array('id'),
+            array('userid', 'identifier', 'timeretrieved', 'token')
+        );
+        $pluginwrapper->add_child($vericitetokens);
+        $vericitetokens->add_child($vericitetoken);
+        if ($userinfo) {
+            $vericitetoken->set_source_table('plagiarism_vericite_tokens', array('cm' => backup::VAR_PARENTID));
+        }
     }
 }

--- a/backup/moodle2/restore_plagiarism_vericite_plugin.class.php
+++ b/backup/moodle2/restore_plagiarism_vericite_plugin.class.php
@@ -27,6 +27,18 @@ class restore_plagiarism_vericite_plugin extends restore_plagiarism_plugin {
         $elepath = $this->get_pathfor('vericite_configs/vericite_config');
         $paths[] = new restore_path_element($elename, $elepath);
 
+        $elename = 'vericitescoremod';
+        $elepath = $this->get_pathfor('vericite_scores/vericite_score');
+        $paths[] = new restore_path_element($elename, $elepath);
+
+        $elename = 'vericitefiles';
+        $elepath = $this->get_pathfor('vericite_files/vericite_file');
+        $paths[] = new restore_path_element($elename, $elepath);
+
+        $elename = 'vericitetokens';
+        $elepath = $this->get_pathfor('vericite_tokens/vericite_token');
+        $paths[] = new restore_path_element($elename, $elepath);
+
         return $paths;
 
     }
@@ -47,6 +59,66 @@ class restore_plagiarism_vericite_plugin extends restore_plagiarism_plugin {
                 $data->cm = $this->task->get_moduleid();
 
                 $DB->insert_record('plagiarism_vericite_config', $data);
+            }
+        }
+    }
+
+    public function process_vericitescoremod($data) {
+        global $DB;
+
+        if ($this->task->is_samesite() && !$this->existingcourse) {
+            if (! is_object($data)) {
+                $data = (object) $data;
+            }
+            $recexists = $DB->record_exists(
+                'plagiarism_vericite_score',
+                array('timeretrieved' => $data->timeretrieved, 'cm' => $this->task->get_moduleid())
+            );
+            if (!$recexists) {
+                $data = (object)$data;
+                $data->cm = $this->task->get_moduleid();
+
+                $DB->insert_record('plagiarism_vericite_score', $data);
+            }
+        }
+    }
+
+    public function process_vericitefiles($data) {
+        global $DB;
+
+        if ($this->task->is_samesite() && !$this->existingcourse) {
+            $data = (object)$data;
+            $recexists = false;
+            if (!empty($data->identifier)) {
+                $recexists = $DB->record_exists(
+                    'plagiarism_vericite_files', array('identifier' => $data->identifier)
+                );
+            }
+            if (!$recexists) {
+                $data->cm = $this->task->get_moduleid();
+                $data->userid = $this->get_mappingid('user', $data->userid);
+
+                $DB->insert_record('plagiarism_vericite_files', $data);
+            }
+        }
+    }
+
+    public function process_vericitetokens($data) {
+        global $DB;
+
+        if ($this->task->is_samesite() && !$this->existingcourse) {
+            $data = (object)$data;
+            $recexists = false;
+            if (!empty($data->identifier)) {
+                $recexists = $DB->record_exists(
+                    'plagiarism_vericite_tokens', array('identifier' => $data->identifier)
+                );
+            }
+            if (!$recexists) {
+                $data->cm = $this->task->get_moduleid();
+                $data->userid = $this->get_mappingid('user', $data->userid);
+
+                $DB->insert_record('plagiarism_vericite_tokens', $data);
             }
         }
     }


### PR DESCRIPTION
Given that my last request to add config backups was easily accepted I decided to complete the backup class and include the other plugin tables. Backing up these tables is only going to be needed in the case a course needs to be restored due to some mishap, but it's a good thing to have just in case. The files and tokens tables are considered to be "user data" so will only be backed up if users are included in the backup.
